### PR TITLE
Fixed white space anchoring

### DIFF
--- a/css/main_.css
+++ b/css/main_.css
@@ -154,7 +154,7 @@ p:after{
 .links a{
 	color:#006400;
 	text-decoration:none;
-	display:block;
+	display:inline-block;
 }
 .links a:hover{
 	text-decoration:underline;


### PR DESCRIPTION
Changed the display attribute of ".links a" to inline-block (instead of block). Therefore the anchors in the links part won't take over the full width of the parent block and eventually the white space won't be anchored. The white spaces can still be made with a HTML <br> tag.